### PR TITLE
FIx brainnco link

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,6 @@ jobs:
         with:
           tag_name: ${{ needs.mix_publish.outputs.version }}
           release_name: Release ${{ needs.mix_publish.outputs.version }}
-          body: Checkout the [changelog](https://github.com/brainn-co/xcribe/blob/master/CHANGELOG.md)
+          body: Checkout the [changelog](https://github.com/brainnco/xcribe/blob/master/CHANGELOG.md)
           draft: false
           prerelease: false


### PR DESCRIPTION
## Motivation

The name of the organization was updated. Because of that the link is taking to nowhere.

## Proposed solution

Fix link generated in releases.
The link in old releases was already updated.