### PR TITLE
Add options do xcribe.doc Task

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ By Xcribe task:
 mix xcribe.doc
 ```
 
+See `Mix.Tasks.Xcribe.Doc`
+
 A file will be created with the documentation on configured format and output path.
 
 You also can generate documentation while running `mix test`. To do that you

--- a/coveralls.json
+++ b/coveralls.json
@@ -1,3 +1,3 @@
 {
-  "skip_files": ["lib/xcribe/application.ex", "test/support", "lib/mix/tasks/"]
+  "skip_files": ["lib/xcribe/application.ex", "test/support"]
 }

--- a/lib/mix/tasks/xcribe.doc.ex
+++ b/lib/mix/tasks/xcribe.doc.ex
@@ -2,12 +2,31 @@ defmodule Mix.Tasks.Xcribe.Doc do
   @moduledoc """
   Run tests with `Xcribe.Document.document/2` macro and generate documentation.
 
+  You can override the application config by passing the arguments `--format` and `--output`
+
+  ```sh
+  mix xcribe.doc -f swagger -o /home/user/api.doc
+  ```
+
+  You can generate doc for an specific endpoint by passing it as argument
+
+  ```sh
+  mix xcribe.doc -e YourAppWeb.Endpoint
+  ```
+
+  You can also pass options to Mix.Tasks.Test task. Ex to running an specific file
+  to generate doc
+
+  ```sh
+  mix xcribe.doc test/you_app_web/controllers/users_controller_test.exs:20
+  ```
+
   Note: to use this task you must configure `preferred_cli_env: ["xcribe.doc": :test]`
   on your `mix.ex` file.
   """
   use Mix.Task
 
-  alias Xcribe.{CLI.Output, Recorder}
+  alias Xcribe.{CLI.Output, Config, Recorder}
 
   @requirements ["app.start"]
 
@@ -16,19 +35,34 @@ defmodule Mix.Tasks.Xcribe.Doc do
   @shortdoc "Generate Xcribe documentation by running tests"
 
   @doc false
-  def run(_opts) do
-    Recorder.set_active(true)
+  def run(opts), do: run_task(opts)
 
+  @doc false
+  def run_task(opts, task_function \\ &run_mix_test_task/1, project_module \\ Mix.Project) do
+    opts
+    |> build_options(project_module)
+    |> run_tests(task_function, project_module)
+  end
+
+  defp run_mix_test_task(opts), do: Mix.Task.run("test", opts)
+
+  defp run_tests({:error, errors}, _task_function, _project_module) do
+    Output.print_configuration_errors(errors)
+
+    Output.print_message("Xcribe Task - aborted", :error)
+
+    exit({:shutdown, 1})
+  end
+
+  defp run_tests({:ok, options}, task_function, project_module) do
+    Recorder.set_active(true)
     Output.print_message("Xcribe Task - starting capture requests")
 
-    Mix.Task.run("test", @mix_test_opts)
+    task_function.(build_mix_test_opts(options))
 
-    IO.puts("\n")
     Output.print_message("Xcribe Task - starting doc generation")
 
-    override_configs = if Mix.Project.umbrella?(), do: &override_configs_func/2, else: nil
-
-    case Xcribe.document_all_records(override_configs) do
+    case Xcribe.document_all_records(override_configs(options, project_module)) do
       :ok ->
         Output.print_message("Xcribe Task - finished")
         :ok
@@ -39,13 +73,77 @@ defmodule Mix.Tasks.Xcribe.Doc do
     end
   end
 
-  @doc false
-  defp override_configs_func(endpoint, configs) do
+  defp build_mix_test_opts(options) do
+    additional_opts =
+      options
+      |> Map.get(:endpoint, [])
+      |> List.wrap()
+      |> Enum.concat(options.ignored)
+
+    Enum.concat(@mix_test_opts, additional_opts)
+  end
+
+  defp override_configs(options, project_module) do
+    if project_module.umbrella?() do
+      fn endpoint, configs ->
+        endpoint
+        |> override_path_for_umbrella(configs, project_module)
+        |> task_config_override(options)
+      end
+    else
+      fn _endpoint, configs ->
+        task_config_override(configs, options)
+      end
+    end
+  end
+
+  defp override_path_for_umbrella(endpoint, configs, project_module) do
     app_name = endpoint.config(:otp_app)
 
-    case Mix.Project.deps_paths()[app_name] do
+    case project_module.deps_paths()[app_name] do
       nil -> configs
       path -> %{configs | output: Path.join(path, configs.output)}
     end
   end
+
+  defp task_config_override(configs, override) do
+    Map.merge(configs, Map.take(override, [:output, :format]))
+  end
+
+  defp build_options(opts, project_module) do
+    {options, rest, _invalid} =
+      OptionParser.parse_head(opts,
+        aliases: [o: :output, f: :format, e: :endpoint],
+        strict: [output: :string, format: :string, endpoint: :string]
+      )
+
+    options
+    |> Map.new()
+    |> Map.put(:ignored, rest)
+    |> validate_format()
+    |> endpoint_path(project_module)
+  end
+
+  defp validate_format(%{format: format} = options) do
+    Config.check_configurations(
+      %{options | format: String.to_atom(format)},
+      [:format]
+    )
+  end
+
+  defp validate_format(options), do: {:ok, options}
+
+  defp endpoint_path({:ok, %{endpoint: endpoint} = options}, project_module) do
+    with module <- String.to_atom("Elixir.#{endpoint}"),
+         true <- function_exported?(module, :config, 1),
+         app_name <- module.config(:otp_app),
+         path when is_binary(path) <- project_module.deps_paths()[app_name] do
+      {:ok, %{options | endpoint: path}}
+    else
+      _any ->
+        {:error, [{:endpoint, endpoint, "Couldn't find a path to endpoint #{endpoint}", ""}]}
+    end
+  end
+
+  defp endpoint_path(options, _project_module), do: options
 end

--- a/lib/xcribe.ex
+++ b/lib/xcribe.ex
@@ -121,8 +121,8 @@ defmodule Xcribe do
     Enum.reduce_while(recorded, {:ok, []}, fn {endpoint, records}, {:ok, acc} ->
       endpoint
       |> Config.fetch_config()
-      |> Config.check_configurations()
       |> apply_override(override_func, endpoint)
+      |> Config.check_configurations()
       |> case do
         {:ok, config} -> {:cont, {:ok, [{records, config} | acc]}}
         {:error, _errs} = error -> {:halt, error}
@@ -132,8 +132,8 @@ defmodule Xcribe do
 
   defp fetch_config(error, _function), do: error
 
-  defp apply_override({:ok, config}, function, endpoint) when is_function(function, 2) do
-    {:ok, function.(endpoint, config)}
+  defp apply_override(config, function, endpoint) when is_function(function, 2) do
+    function.(endpoint, config)
   end
 
   defp apply_override(config, _function, _endpoint), do: config

--- a/test/xcribe/tasks/doc_test.exs
+++ b/test/xcribe/tasks/doc_test.exs
@@ -1,4 +1,4 @@
-defmodule Tasks.Xcribe.DocTest do
+defmodule Xcribe.Tasks.DocTest do
   use ExUnit.Case, async: false
 
   import ExUnit.CaptureIO
@@ -54,15 +54,15 @@ defmodule Tasks.Xcribe.DocTest do
 
       output = "/tmp/task_tests.doc"
 
-      Application.put_env(:xcribe, Tasks.Xcribe.DocTest.FakeEndpoint,
-        information_source: Tasks.Xcribe.DocTest.FakeInformation,
+      Application.put_env(:xcribe, Xcribe.Tasks.DocTest.FakeEndpoint,
+        information_source: Xcribe.Tasks.DocTest.FakeInformation,
         output: output
       )
 
       File.rm(output)
 
       on_exit(fn ->
-        Application.delete_env(:xcribe, Tasks.Xcribe.DocTest.FakeEndpoint)
+        Application.delete_env(:xcribe, Xcribe.Tasks.DocTest.FakeEndpoint)
       end)
     end
 
@@ -72,7 +72,7 @@ defmodule Tasks.Xcribe.DocTest do
 
         Recorder.add(%{
           RequestsGenerator.users_index()
-          | endpoint: Tasks.Xcribe.DocTest.FakeEndpoint
+          | endpoint: Xcribe.Tasks.DocTest.FakeEndpoint
         })
       end
 
@@ -92,7 +92,7 @@ defmodule Tasks.Xcribe.DocTest do
 
         Recorder.add(%{
           RequestsGenerator.users_index()
-          | endpoint: Tasks.Xcribe.DocTest.FakeEndpoint
+          | endpoint: Xcribe.Tasks.DocTest.FakeEndpoint
         })
       end
 
@@ -117,7 +117,7 @@ defmodule Tasks.Xcribe.DocTest do
 
         Recorder.add(%{
           RequestsGenerator.users_index()
-          | endpoint: Tasks.Xcribe.DocTest.FakeEndpoint
+          | endpoint: Xcribe.Tasks.DocTest.FakeEndpoint
         })
       end
 
@@ -132,8 +132,8 @@ defmodule Tasks.Xcribe.DocTest do
     test "keep path when cant find deps path for umbrella app" do
       output = "/tmp/task_tests.doc"
 
-      Application.put_env(:xcribe, Tasks.Xcribe.DocTest.FailFakeEndpoint,
-        information_source: Tasks.Xcribe.DocTest.FakeInformation,
+      Application.put_env(:xcribe, Xcribe.Tasks.DocTest.FailFakeEndpoint,
+        information_source: Xcribe.Tasks.DocTest.FakeInformation,
         output: output
       )
 
@@ -142,13 +142,13 @@ defmodule Tasks.Xcribe.DocTest do
 
         Recorder.add(%{
           RequestsGenerator.users_index()
-          | endpoint: Tasks.Xcribe.DocTest.FailFakeEndpoint
+          | endpoint: Xcribe.Tasks.DocTest.FailFakeEndpoint
         })
       end
 
       io_output = capture_io(fn -> Doc.run_task([], mix_test_fun, FakeProject) end)
 
-      Application.delete_env(:xcribe, Tasks.Xcribe.DocTest.FailFakeEndpoint)
+      Application.delete_env(:xcribe, Xcribe.Tasks.DocTest.FailFakeEndpoint)
 
       assert io_output =~ "documentation written in #{output}"
       assert File.read!(output) =~ "securitySchemes"
@@ -162,14 +162,14 @@ defmodule Tasks.Xcribe.DocTest do
 
         Recorder.add(%{
           RequestsGenerator.users_index()
-          | endpoint: Tasks.Xcribe.DocTest.FakeEndpoint
+          | endpoint: Xcribe.Tasks.DocTest.FakeEndpoint
         })
       end
 
       io_output =
         capture_io(fn ->
           Doc.run_task(
-            ["--endpoint", "Tasks.Xcribe.DocTest.FakeEndpoint"],
+            ["--endpoint", "Xcribe.Tasks.DocTest.FakeEndpoint"],
             mix_test_fun,
             FakeProject
           )
@@ -239,23 +239,23 @@ defmodule Tasks.Xcribe.DocTest do
     end
 
     test "when cant find otp_app path" do
-      Application.put_env(:xcribe, Tasks.Xcribe.DocTest.FailFakeEndpoint,
-        information_source: Tasks.Xcribe.DocTest.FakeInformation
+      Application.put_env(:xcribe, Xcribe.Tasks.DocTest.FailFakeEndpoint,
+        information_source: Xcribe.Tasks.DocTest.FakeInformation
       )
 
       assert capture_io(fn ->
                try do
                  Doc.run_task(
-                   ["--endpoint", "Tasks.Xcribe.DocTest.FailFakeEndpoint"],
+                   ["--endpoint", "Xcribe.Tasks.DocTest.FailFakeEndpoint"],
                    nil,
                    FakeProject
                  )
                catch
                  :exit, message ->
-                   Application.delete_env(:xcribe, Tasks.Xcribe.DocTest.FailFakeEndpoint)
+                   Application.delete_env(:xcribe, Xcribe.Tasks.DocTest.FailFakeEndpoint)
                    assert message == {:shutdown, 1}
                end
-             end) =~ "Couldn't find a path to endpoint Tasks.Xcribe.DocTest.FailFakeEndpoint"
+             end) =~ "Couldn't find a path to endpoint Xcribe.Tasks.DocTest.FailFakeEndpoint"
     end
 
     test "invalid format option" do

--- a/test/xcribe/tasks/xcribe.doc_test.exs
+++ b/test/xcribe/tasks/xcribe.doc_test.exs
@@ -1,0 +1,187 @@
+defmodule Tasks.Xcribe.DocTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureIO
+
+  alias Mix.Tasks.Xcribe.Doc
+  alias Xcribe.Recorder
+  alias Xcribe.Support.RequestsGenerator
+
+  @mix_test_default_opts [
+    "--only",
+    "xcribe_document",
+    "--formatter",
+    "Xcribe.Tasks.Formatter",
+    "--max-failures",
+    "1"
+  ]
+
+  defmodule FakeInformation do
+    use Xcribe.Information
+  end
+
+  defmodule FakeEndpoint do
+    def config(:otp_app), do: "fake_app"
+  end
+
+  defmodule FailFakeEndpoint do
+    def config(:otp_app), do: "fail_fake_app"
+  end
+
+  defmodule FakeProject do
+    def deps_paths, do: %{"fake_app" => "/tmp/fake_app"}
+    def umbrella?, do: true
+  end
+
+  defmodule FakeProjectNonUmbrella do
+    def umbrella?, do: false
+  end
+
+  describe "run task" do
+    setup do
+      Recorder.pop_all()
+
+      output = "/tmp/task_tests.doc"
+
+      Application.put_env(:xcribe, Tasks.Xcribe.DocTest.FakeEndpoint,
+        information_source: Tasks.Xcribe.DocTest.FakeInformation,
+        output: output
+      )
+
+      File.rm(output)
+
+      on_exit(fn ->
+        Application.delete_env(:xcribe, Tasks.Xcribe.DocTest.FakeEndpoint)
+      end)
+    end
+
+    test "run mix test and generate documentation" do
+      mix_test_fun = fn opts ->
+        assert opts == @mix_test_default_opts
+
+        Recorder.add(%{
+          RequestsGenerator.users_index()
+          | endpoint: Tasks.Xcribe.DocTest.FakeEndpoint
+        })
+      end
+
+      output = capture_io(fn -> Doc.run_task([], mix_test_fun, FakeProjectNonUmbrella) end)
+
+      assert output =~ "starting capture requests"
+      assert output =~ "starting doc generation"
+      assert output =~ "documentation written in /tmp/task_tests.doc"
+      assert output =~ "Xcribe Task - finished"
+      assert File.exists?("/tmp/task_tests.doc")
+      assert Recorder.pop_all() == %{errors: []}
+    end
+
+    test "run task with custom output and format" do
+      mix_test_fun = fn opts ->
+        assert opts == @mix_test_default_opts
+
+        Recorder.add(%{
+          RequestsGenerator.users_index()
+          | endpoint: Tasks.Xcribe.DocTest.FakeEndpoint
+        })
+      end
+
+      output =
+        capture_io(fn ->
+          Doc.run_task(
+            ["--format", "api_blueprint", "--output", "/tmp/custom_output_task_test.doc"],
+            mix_test_fun,
+            FakeProjectNonUmbrella
+          )
+        end)
+
+      assert output =~ "documentation written in /tmp/custom_output_task_test.doc"
+      assert File.read!("/tmp/custom_output_task_test.doc") =~ "FORMAT: 1A"
+      assert File.rm!("/tmp/custom_output_task_test.doc")
+      assert Recorder.pop_all() == %{errors: []}
+    end
+
+    test "override path for umbrella apps" do
+      mix_test_fun = fn opts ->
+        assert opts == @mix_test_default_opts
+
+        Recorder.add(%{
+          RequestsGenerator.users_index()
+          | endpoint: Tasks.Xcribe.DocTest.FakeEndpoint
+        })
+      end
+
+      output = capture_io(fn -> Doc.run_task([], mix_test_fun, FakeProject) end)
+
+      assert output =~ "documentation written in /tmp/fake_app/tmp/task_tests.doc"
+      assert File.read!("/tmp/fake_app/tmp/task_tests.doc") =~ "securitySchemes"
+      assert File.rm!("/tmp/fake_app/tmp/task_tests.doc")
+      assert Recorder.pop_all() == %{errors: []}
+    end
+
+    test "generate docs for a specific endpoint" do
+      mix_test_fun = fn opts ->
+        assert opts == @mix_test_default_opts ++ ["/tmp/fake_app"]
+
+        Recorder.add(%{
+          RequestsGenerator.users_index()
+          | endpoint: Tasks.Xcribe.DocTest.FakeEndpoint
+        })
+      end
+
+      output =
+        capture_io(fn ->
+          Doc.run_task(
+            ["--endpoint", "Tasks.Xcribe.DocTest.FakeEndpoint"],
+            mix_test_fun,
+            FakeProject
+          )
+        end)
+
+      assert output =~ "documentation written in /tmp/fake_app/tmp/task_tests.doc"
+      assert File.read!("/tmp/fake_app/tmp/task_tests.doc") =~ "securitySchemes"
+      assert File.rm!("/tmp/fake_app/tmp/task_tests.doc")
+      assert Recorder.pop_all() == %{errors: []}
+    end
+
+    test "send to test's task ignored options" do
+      mix_test_fun = fn opts ->
+        assert opts == @mix_test_default_opts ++ ["/custom/file/path", "--other", "value"]
+      end
+
+      output =
+        capture_io(fn ->
+          Doc.run_task(["/custom/file/path", "--other", "value"], mix_test_fun, FakeProject)
+        end)
+
+      assert output =~ "Xcribe Task - finished"
+    end
+
+    test "invalid endpoint module" do
+      assert capture_io(fn ->
+               Doc.run_task(["--endpoint", "InvalidEndpoint"])
+             end) =~ "Couldn't find a path to endpoint InvalidEndpoint"
+    catch
+      :exit, message -> assert message == {:shutdown, 1}
+    end
+
+    test "when cant find otp_app path" do
+      assert capture_io(fn ->
+               Doc.run_task(
+                 ["--endpoint", "Tasks.Xcribe.DocTest.FailFakeEndpoint"],
+                 nil,
+                 FakeProject
+               )
+             end) =~ "Couldn't find a path to endpoint InvalidEndpoint"
+    catch
+      :exit, message -> assert message == {:shutdown, 1}
+    end
+
+    test "invalid format option" do
+      assert capture_io(fn ->
+               Doc.run_task(["--format", "invalid"])
+             end) =~ "Xcribe doesn't support the configured documentation format"
+    catch
+      :exit, message -> assert message == {:shutdown, 1}
+    end
+  end
+end


### PR DESCRIPTION
## Motivation
Allow pass options to `xcribe.doc` task.

## Proposed solution

- Allow override format and output config
- Allow run docs for a specific Endpoint
- Allow pass options to `Mix.Tasks.Test` (eg a specific file to run tests)